### PR TITLE
Fix file not found error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,8 @@ runs:
   - name: Run Webhook
     shell: bash
     run: |
-      chmod +x entrypoint.sh
+      cd ${{github.action_path}}
+      chmod +x ./entrypoint.sh
       ./entrypoint.sh
       
 branding:


### PR DESCRIPTION
Fixed an error where the action would fail in pipelines that depend on it, because the action would not CD into its own directory before attempting to execute the webhook script.